### PR TITLE
Add check for jwt token expiry while validating

### DIFF
--- a/authservice/jwt/jwt.go
+++ b/authservice/jwt/jwt.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	TOKEN_IS_CORRUPT = "Token is corrupt"
-	INVALID_TOKEN    = "Invalid Token"
-	TOKEN_EXPIRED    = "Token Expired"
+	CORRUPT_TOKEN = "Corrupt Token"
+	INVALID_TOKEN = "Invalid Token"
+	EXPIRED_TOKEN = "Expired Token"
 )
 
 // claims are attributes.
@@ -70,7 +70,7 @@ func ValidateToken(token string, secret string) error {
 	splitToken := strings.Split(token, ".")
 	// if length is not 3, we know that the token is corrupt
 	if len(splitToken) != 3 {
-		return errors.New(TOKEN_IS_CORRUPT)
+		return errors.New(CORRUPT_TOKEN)
 	}
 
 	// decode the header and payload back to strings
@@ -101,7 +101,7 @@ func ValidateToken(token string, secret string) error {
 
 	//Check if token is expired
 	if payloadMap.Exp < fmt.Sprint(time.Now().Unix()) {
-		return errors.New(TOKEN_EXPIRED)
+		return errors.New(EXPIRED_TOKEN)
 	}
 
 	// This means the token matches

--- a/authservice/jwt/jwt.go
+++ b/authservice/jwt/jwt.go
@@ -5,10 +5,28 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
+
+const (
+	TOKEN_IS_CORRUPT = "Token is corrupt"
+	INVALID_TOKEN    = "Invalid Token"
+	TOKEN_EXPIRED    = "Token Expired"
+)
+
+// claims are attributes.
+// Aud - audience
+// Iss - issuer
+// Exp - expiration of the Token
+type ClaimsMap struct {
+	Aud string
+	Iss string
+	Exp string
+}
 
 // GetSecret fetches the value for the JWT_SECRET from the environment variable
 func GetSecret() string {
@@ -16,7 +34,7 @@ func GetSecret() string {
 }
 
 // Function for generating the tokens.
-func GenerateToken(header string, payload map[string]string, secret string) (string, error) {
+func GenerateToken(header string, payload ClaimsMap, secret string) (string, error) {
 	// create a new hash of type sha256. We pass the secret key to it
 	// sha256 is a symmetric cryptographic algorithm
 	h := hmac.New(sha256.New, []byte(secret))
@@ -47,22 +65,22 @@ func GenerateToken(header string, payload map[string]string, secret string) (str
 }
 
 // This helps in validating the token
-func ValidateToken(token string, secret string) (bool, error) {
+func ValidateToken(token string, secret string) error {
 	// JWT has 3 parts separated by '.'
 	splitToken := strings.Split(token, ".")
 	// if length is not 3, we know that the token is corrupt
 	if len(splitToken) != 3 {
-		return false, nil
+		return errors.New(TOKEN_IS_CORRUPT)
 	}
 
 	// decode the header and payload back to strings
 	header, err := base64.StdEncoding.DecodeString(splitToken[0])
 	if err != nil {
-		return false, err
+		return err
 	}
 	payload, err := base64.StdEncoding.DecodeString(splitToken[1])
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	//again create the signature
@@ -74,8 +92,18 @@ func ValidateToken(token string, secret string) (bool, error) {
 
 	// if both the signature dont match, this means token is wrong
 	if signature != splitToken[2] {
-		return false, nil
+		return errors.New(INVALID_TOKEN)
 	}
+
+	//Unmarshal payload into ClaimsMap struct
+	var payloadMap ClaimsMap
+	json.Unmarshal(payload, &payloadMap)
+
+	//Check if token is expired
+	if payloadMap.Exp < fmt.Sprint(time.Now().Unix()) {
+		return errors.New(TOKEN_EXPIRED)
+	}
+
 	// This means the token matches
-	return true, nil
+	return nil
 }

--- a/authservice/jwt/jwt_test.go
+++ b/authservice/jwt/jwt_test.go
@@ -18,21 +18,21 @@ func TestTokenValidation(t *testing.T) {
 	if err != nil {
 		t.Error("Token generation failed")
 	}
-	//Token with long expiry date must not be expired
-	if TOKEN_EXPIRED == fmt.Sprint(ValidateToken(longExpiryToken, secret)) {
+	//Token with long expiry date must not be expired at this time
+	if EXPIRED_TOKEN == fmt.Sprint(ValidateToken(longExpiryToken, secret)) {
 		t.Error("Token must not be expired")
 	}
 
-	//Corrupt token i.e without 3 sections must throw 'Token is Corrupt' on validation
+	//Corrupt token i.e without 3 sections must throw 'Token is corrupt' on validation
 	corruptTokenString := "randomcorrupttokenstring"
-	if TOKEN_IS_CORRUPT != fmt.Sprint(ValidateToken(corruptTokenString, secret)) {
+	if CORRUPT_TOKEN != fmt.Sprint(ValidateToken(corruptTokenString, secret)) {
 		t.Error("Should throw 'Token is corrupt' for corrupt tokens")
 	}
 
 	//Invalid token i.e signature mismatched token must throw 'Invalid Token' on validation
 	invalidTokenString := longExpiryToken + "randomsignaturesuffix"
 	if INVALID_TOKEN != fmt.Sprint(ValidateToken(invalidTokenString, secret)) {
-		t.Error("Should throw 'Token is invalid' for invalid tokens")
+		t.Error("Should throw 'Invalid Token' for invalid tokens")
 	}
 
 	shortExpiryClaims := ClaimsMap{
@@ -48,7 +48,7 @@ func TestTokenValidation(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	//Expired token must throw 'Token Expired' on validation
-	if TOKEN_EXPIRED != fmt.Sprint(ValidateToken(shortExpiryToken, secret)) {
+	if EXPIRED_TOKEN != fmt.Sprint(ValidateToken(shortExpiryToken, secret)) {
 		t.Error("Failed to detect expired token")
 	}
 

--- a/authservice/jwt/jwt_test.go
+++ b/authservice/jwt/jwt_test.go
@@ -1,0 +1,55 @@
+package jwt
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestTokenValidation(t *testing.T) {
+
+	secret := GetSecret()
+	longExpiryClaims := ClaimsMap{
+		Aud: "frontend.knowsearch.ml",
+		Iss: "knowsearch.ml",
+		Exp: fmt.Sprint(time.Now().Add(time.Minute * 60).Unix()),
+	}
+	longExpiryToken, err := GenerateToken("HS256", longExpiryClaims, secret)
+	if err != nil {
+		t.Error("Token generation failed")
+	}
+	//Token with long expiry date must not be expired
+	if TOKEN_EXPIRED == fmt.Sprint(ValidateToken(longExpiryToken, secret)) {
+		t.Error("Token must not be expired")
+	}
+
+	//Corrupt token i.e without 3 sections must throw 'Token is Corrupt' on validation
+	corruptTokenString := "randomcorrupttokenstring"
+	if TOKEN_IS_CORRUPT != fmt.Sprint(ValidateToken(corruptTokenString, secret)) {
+		t.Error("Should throw 'Token is corrupt' for corrupt tokens")
+	}
+
+	//Invalid token i.e signature mismatched token must throw 'Invalid Token' on validation
+	invalidTokenString := longExpiryToken + "randomsignaturesuffix"
+	if INVALID_TOKEN != fmt.Sprint(ValidateToken(invalidTokenString, secret)) {
+		t.Error("Should throw 'Token is invalid' for invalid tokens")
+	}
+
+	shortExpiryClaims := ClaimsMap{
+		Aud: "frontend.knowsearch.ml",
+		Iss: "knowsearch.ml",
+		Exp: fmt.Sprint(time.Now().Unix()),
+	}
+	shortExpiryToken, err := GenerateToken("HS256", shortExpiryClaims, secret)
+	if err != nil {
+		t.Error("Token generation failed")
+	}
+	//Sleep for 5 seconds to ensure token is expired
+	time.Sleep(5 * time.Second)
+
+	//Expired token must throw 'Token Expired' on validation
+	if TOKEN_EXPIRED != fmt.Sprint(ValidateToken(shortExpiryToken, secret)) {
+		t.Error("Failed to detect expired token")
+	}
+
+}

--- a/authservice/middleware/middleware.go
+++ b/authservice/middleware/middleware.go
@@ -45,7 +45,7 @@ func (ctrl *TokenMiddleware) TokenValidationMiddleware(next http.Handler) http.H
 		if err != nil {
 			errInString := fmt.Sprint(err)
 			ctrl.logger.Error(errInString, zap.String("token", token))
-			if errInString == jwt.TOKEN_IS_CORRUPT || errInString == jwt.INVALID_TOKEN || errInString == jwt.TOKEN_EXPIRED {
+			if errInString == jwt.CORRUPT_TOKEN || errInString == jwt.INVALID_TOKEN || errInString == jwt.EXPIRED_TOKEN {
 				rw.WriteHeader(http.StatusUnauthorized)
 			} else {
 				rw.WriteHeader(http.StatusInternalServerError)

--- a/authservice/middleware/middleware.go
+++ b/authservice/middleware/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/shadowshot-x/micro-product-go/authservice/jwt"
@@ -40,17 +41,16 @@ func (ctrl *TokenMiddleware) TokenValidationMiddleware(next http.Handler) http.H
 			return
 		}
 
-		check, err := jwt.ValidateToken(token, secret)
+		err := jwt.ValidateToken(token, secret)
 		if err != nil {
-			ctrl.logger.Error("Token Validation Failed", zap.String("token", token))
-			rw.WriteHeader(http.StatusInternalServerError)
-			rw.Write([]byte("Token Validation Failed"))
-			return
-		}
-		if !check {
-			ctrl.logger.Warn("Token invalid", zap.String("token", token))
-			rw.WriteHeader(http.StatusUnauthorized)
-			rw.Write([]byte("Token Invalid"))
+			errInString := fmt.Sprint(err)
+			ctrl.logger.Error(errInString, zap.String("token", token))
+			if errInString == jwt.TOKEN_IS_CORRUPT || errInString == jwt.INVALID_TOKEN || errInString == jwt.TOKEN_EXPIRED {
+				rw.WriteHeader(http.StatusUnauthorized)
+			} else {
+				rw.WriteHeader(http.StatusInternalServerError)
+			}
+			rw.Write([]byte(errInString))
 			return
 		}
 		// rw.WriteHeader(http.StatusOK)

--- a/authservice/signin.go
+++ b/authservice/signin.go
@@ -41,18 +41,18 @@ func NewSigninController(logger *zap.Logger) *SigninController {
 func getSignedToken() (string, error) {
 	// we make a JWT Token here with signing method of ES256 and claims.
 	// claims are attributes.
-	// aud - audience
-	// iss - issuer
-	// exp - expiration of the Token
+	// Aud - audience
+	// Iss - issuer
+	// Exp - expiration of the Token
 	// token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-	// 	"aud": "frontend.knowsearch.ml",
-	// 	"iss": "knowsearch.ml",
-	// 	"exp": string(time.Now().Add(time.Minute * 1).Unix()),
+	// 	"Aud": "frontend.knowsearch.ml",
+	// 	"Iss": "knowsearch.ml",
+	// 	"Exp": string(time.Now().Add(time.Minute * 1).Unix()),
 	// })
-	claimsMap := map[string]string{
-		"aud": "frontend.knowsearch.ml",
-		"iss": "knowsearch.ml",
-		"exp": fmt.Sprint(time.Now().Add(time.Minute * 1).Unix()),
+	claimsMap := jwt.ClaimsMap{
+		Aud: "frontend.knowsearch.ml",
+		Iss: "knowsearch.ml",
+		Exp: fmt.Sprint(time.Now().Add(time.Minute * 1).Unix()),
 	}
 
 	secret := jwt.GetSecret()


### PR DESCRIPTION
Closes #1 


**Changes:**
- Adds check if jwt token is expired in validation function
- Create struct for ClaimsMap with exported fields
- Create constants for jwt token related error messages
- Tests for token validation function for cases - corrupt token, invalid token and expired token